### PR TITLE
Passing --lib to cabal install seems necessary to avoid "cannot build the executables" issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git clone https://github.com/lvm/tidal-drum-patterns \
     && cabal clean \
     && cabal configure \
     && cabal build \
-    && cabal install
+    && cabal install --lib
 ```
 
 ## Usage


### PR DESCRIPTION
Just got bitten by this as a cabal newbie. Thanks for your work!